### PR TITLE
Fix expo secure store polyfill

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -11,6 +11,6 @@ export async function apiRequest(path, options = {}) {
 }
 
 export async function getToken() {
-  const SecureStore = require('expo-secure-store');
+  const SecureStore = require('../utils/secureStore');
   return SecureStore.getItemAsync('token');
 }

--- a/screens/CustomerDashboard.tsx
+++ b/screens/CustomerDashboard.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import React from 'react';
 import { View, Text, Button } from 'react-native';
-import * as SecureStore from 'expo-secure-store';
+import * as SecureStore from '../utils/secureStore';
 
 export default function CustomerDashboard({ navigation }) {
   async function handleLogout() {

--- a/screens/LoginScreen.tsx
+++ b/screens/LoginScreen.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button, Alert } from 'react-native';
-import * as SecureStore from 'expo-secure-store';
+import * as SecureStore from '../utils/secureStore';
 import { apiRequest } from '../lib/api';
 
 export default function LoginScreen({ navigation }) {

--- a/screens/ProviderDashboard.tsx
+++ b/screens/ProviderDashboard.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import React, { useEffect, useState } from 'react';
 import { View, Text, Button, FlatList, TouchableOpacity } from 'react-native';
-import * as SecureStore from 'expo-secure-store';
+import * as SecureStore from '../utils/secureStore';
 import { apiRequest } from '../lib/api';
 
 export default function ProviderDashboard({ navigation }) {

--- a/screens/SplashScreen.tsx
+++ b/screens/SplashScreen.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import React, { useEffect } from "react";
 import { View, ActivityIndicator } from "react-native";
-import * as SecureStore from "expo-secure-store";
+import * as SecureStore from "../utils/secureStore";
 
 export default function SplashScreen({ navigation }) {
   useEffect(() => {

--- a/utils/secureStore.ts
+++ b/utils/secureStore.ts
@@ -1,0 +1,51 @@
+import * as ExpoSecureStore from 'expo-secure-store';
+
+const isWeb = typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+export async function getItem(key: string): Promise<string | null> {
+  if (ExpoSecureStore.getItemAsync) {
+    try {
+      return await ExpoSecureStore.getItemAsync(key);
+    } catch {
+      // fall through to web storage
+    }
+  }
+  if (isWeb) {
+    return Promise.resolve(window.localStorage.getItem(key));
+  }
+  return null;
+}
+
+export const getItemAsync = getItem;
+
+export async function setItem(key: string, value: string): Promise<void> {
+  if (ExpoSecureStore.setItemAsync) {
+    try {
+      await ExpoSecureStore.setItemAsync(key, value);
+      return;
+    } catch {
+      // fall through
+    }
+  }
+  if (isWeb) {
+    window.localStorage.setItem(key, value);
+  }
+}
+
+export const setItemAsync = setItem;
+
+export async function deleteItem(key: string): Promise<void> {
+  if (ExpoSecureStore.deleteItemAsync) {
+    try {
+      await ExpoSecureStore.deleteItemAsync(key);
+      return;
+    } catch {
+      // fall through
+    }
+  }
+  if (isWeb) {
+    window.localStorage.removeItem(key);
+  }
+}
+
+export const deleteItemAsync = deleteItem;


### PR DESCRIPTION
## Summary
- add a lightweight secure store wrapper with a web fallback
- use the wrapper instead of expo-secure-store everywhere

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686462b6906483259bfbb86611b260cc